### PR TITLE
Turning off spooling for emails.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -67,7 +67,7 @@ swiftmailer:
     host:      %mailer_host%
     username:  %mailer_user%
     password:  %mailer_password%
-    spool:     { type: memory }
+    spool:     false
 
 fos_user:
     db_driver: orm # other valid values are 'mongodb', 'couchdb' and 'propel'


### PR DESCRIPTION
We do not have such a heavy load, so no need for a cron job to send emails.

Fixes #24 
