### PR TITLE
Properly disabling spooling.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -67,7 +67,6 @@ swiftmailer:
     host:      %mailer_host%
     username:  %mailer_user%
     password:  %mailer_password%
-    spool:     false
 
 fos_user:
     db_driver: orm # other valid values are 'mongodb', 'couchdb' and 'propel'


### PR DESCRIPTION
This is done by removing the spool option, not by setting it to false.
Closes #24 for good i hope.
